### PR TITLE
fix: extensions items are not of equal size

### DIFF
--- a/app/components/ManageInstalled.js
+++ b/app/components/ManageInstalled.js
@@ -40,7 +40,7 @@ export default class ManageInstalled extends React.Component {
         <div className="sk-panel-row" />
         <div className="sk-h4 sk-bold sk-panel-row">{title}</div>
         <div className="sk-panel-row" />
-        <div className="packages sk-panel-table sk-panel-row">
+        <div className="packages sk-panel-table">
           {extensions.map((ext, index) =>
             <div className="package sk-panel-table-item">
               <PackageView key={ext.uuid} component={ext} hideMeta={true} />


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/5891646/94344661-c9bb0e00-ffee-11ea-9e77-e5cf944f1e95.png)

**After:**
![image](https://user-images.githubusercontent.com/5891646/94344671-e0616500-ffee-11ea-8d1d-0f6b657388a7.png)
